### PR TITLE
fix: sandbox hardening, judge verdict bug, compiler doctor thread safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,7 @@ jobs:
         shell: pwsh
         run: |
           ./scripts/run_tui_regression.ps1 -BuildDir build
-          # Basic CLI smoke test
-          ./build/Release/shuati --help | Select-String "pull", "solve", "status"
-          ./build/Release/shuati status | Select-String "Total problems"
+          # Basic CLI smoke test — verify help shows key subcommands
+          ./build/Release/shuati --help | Select-String "pull", "solve", "list"
+          # 'status' subcommand does not exist; verify 'list' runs without error (DB may be empty)
+          ./build/Release/shuati list -f all 2>$null; if ($LASTEXITCODE -ne 0) { exit 1 }

--- a/src/adapters/ai_coach.cpp
+++ b/src/adapters/ai_coach.cpp
@@ -43,6 +43,8 @@ std::string AICoach::call_api(const std::string& system_prompt, const std::strin
                 body_str,
                 cpr::WriteCallback{
                     [&](std::string_view data, intptr_t) -> bool {
+                        // Guard against unbounded memory growth (max 50MB)
+                        if (buffer.size() > 50 * 1024 * 1024) return false;
                         buffer.append(data.data(), data.size());
                         size_t pos = 0;
                         while ((pos = buffer.find('\n')) != std::string::npos) {

--- a/src/adapters/luogu_crawler.cpp
+++ b/src/adapters/luogu_crawler.cpp
@@ -8,10 +8,14 @@
 namespace shuati {
 
 // Luogu difficulty levels (0-7)
+// 0=入门, 1=普及-, 2=普及/普及+, 3=提高, 4=提高+/省选-,
+// 5=省选, 6=省选+/NOI-, 7=NOI-
 static std::string luogu_difficulty_str(int level) {
     switch (level) {
-        case 1: 
+        case 1:
         case 2: return "easy";
+        case 3:
+        case 4: return "medium";
         case 5:
         case 6:
         case 7: return "hard";

--- a/src/core/compiler_doctor.cpp
+++ b/src/core/compiler_doctor.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <filesystem>
 #include <cstdlib>
+#include <mutex>
 #include <fmt/core.h>
 #include <nlohmann/json.hpp>
 
@@ -12,9 +13,10 @@ namespace shuati {
 
 namespace fs = std::filesystem;
 
-// Static members
+// Static members — thread-safe one-time init via call_once
 std::vector<DiagnosticRule> CompilerDoctor::rules_;
 bool CompilerDoctor::rules_loaded_ = false;
+std::once_flag rules_init_flag_;
 
 bool CompilerDoctor::load_rules(const std::string& json_path) {
     try {
@@ -72,12 +74,11 @@ Diagnosis CompilerDoctor::diagnose(const std::string& error_output) {
     d.description = "无法识别的编译错误，请检查代码逻辑。";
     d.suggestion = "请尝试阅读上方的英文报错信息，或者使用 'hint' 命令询问 AI。";
 
-    // Load rules on first use if not already loaded
-    if (!rules_loaded_) {
-        // Use platform-aware resource path resolution
+    // Load rules on first use — thread-safe via call_once
+    std::call_once(rules_init_flag_, [&]() {
         auto rules_path = get_resource_path("rules/compiler_errors.json");
-        load_rules(rules_path.string());
-    }
+        rules_loaded_ = load_rules(rules_path.string());
+    });
 
     // Try to match against loaded rules
     for (const auto& rule : rules_) {

--- a/src/core/judge.cpp
+++ b/src/core/judge.cpp
@@ -338,9 +338,8 @@ JudgeResult Judge::run_case(const std::string& executable,
         
         if (res.verdict == Verdict::WA) {
             res.message = fmt::format("Expected:\n{}\nActual:\n{}", tc.output, res.output);
-        } else {
-            res.verdict = Verdict::AC;
         }
+        // verdict is already set correctly by check_output (AC or WA)
     }
 
     return res;

--- a/src/core/problem_manager.cpp
+++ b/src/core/problem_manager.cpp
@@ -68,17 +68,8 @@ void ProblemManager::pull_problem(const std::string& url) {
     std::filesystem::path prob_dir = root / Config::DIR_NAME / "problems" / utils::canonical_source(p.source) / p.id;
     if (!std::filesystem::exists(prob_dir)) std::filesystem::create_directories(prob_dir);
     std::string filename = (prob_dir / "problem.md").string();
-    std::ofstream out(filename);
-    out << "# " << p.title << "\n\n"
-        << "来源: " << url << "\n"
-        << "难度: " << p.difficulty << "\n"
-        << "标签: " << p.tags << "\n\n"
-        << "## 题目描述\n\n"
-        << p.description << "\n\n"
-        << "(数据抓取自 " << p.source << ")\n\n"
-        << "## 笔记\n\n";
-    out.close();
-
+    
+    // Save to DB first — if this fails, the file is untouched (DB is source of truth)
     p.content_path = std::filesystem::absolute(filename).string();
     db_->add_problem(p);
 
@@ -97,6 +88,18 @@ void ProblemManager::pull_problem(const std::string& url) {
     r.ease_factor = 2.5;
     r.repetitions = 0;
     db_->upsert_review(r);
+
+    // Write file only after DB insert succeeds
+    std::ofstream out(filename);
+    out << "# " << p.title << "\n\n"
+        << "来源: " << url << "\n"
+        << "难度: " << p.difficulty << "\n"
+        << "标签: " << p.tags << "\n\n"
+        << "## 题目描述\n\n"
+        << p.description << "\n\n"
+        << "(数据抓取自 " << p.source << ")\n\n"
+        << "## 笔记\n\n";
+    out.close();
 
     fmt::print(fg(fmt::color::green), "[+] 题目 '{}' 已保存至 {}\n", p.title, filename);
     fmt::print("    使用 shuati solve {} 开始练习\n", p.id);
@@ -163,7 +166,10 @@ void ProblemManager::delete_problem(const std::string& id) {
     auto p = db_->get_problem(id);
     if (p.id.empty()) return;
 
-    // Delete problem file
+    // Delete from DB first — if this fails, files are untouched
+    if (p.display_id > 0) db_->delete_problem(p.display_id);
+
+    // Only delete files after DB deletion succeeds
     if (std::filesystem::exists(p.content_path)) {
         std::filesystem::remove(p.content_path);
     }
@@ -185,9 +191,6 @@ void ProblemManager::delete_problem(const std::string& id) {
             }
         } catch (...) {}
     }
-
-    // Delete from DB
-    if (p.display_id > 0) db_->delete_problem(p.display_id);
 
     fmt::print(fg(fmt::color::green), "[+] 题目已删除: {} (TID: {})\n", p.title, p.display_id);
 }

--- a/src/core/sandbox/sandbox_linux.cpp
+++ b/src/core/sandbox/sandbox_linux.cpp
@@ -21,7 +21,8 @@ namespace sandbox {
 class LinuxSandbox : public ISandbox {
 private:
     bool has_bwrap() const {
-        return system("which bwrap > /dev/null 2>&1") == 0;
+        static bool cached = system("which bwrap > /dev/null 2>&1") == 0;
+        return cached;
     }
 
 public:
@@ -105,8 +106,9 @@ public:
                 c_args.push_back("--ro-bind"); c_args.push_back("/lib"); c_args.push_back("/lib");
                 c_args.push_back("--ro-bind"); c_args.push_back("/lib64"); c_args.push_back("/lib64");
                 c_args.push_back("--ro-bind"); c_args.push_back("/bin"); c_args.push_back("/bin");
+                c_args.push_back("--ro-bind"); c_args.push_back("/usr/local"); c_args.push_back("/usr/local");
                 c_args.push_back("--proc"); c_args.push_back("/proc");
-                c_args.push_back("--dev"); c_args.push_back("/dev");
+                c_args.push_back("--dev"); c_args.push_back("/dev/shm");
                 c_args.push_back("--unshare-net"); // Disable network
                 c_args.push_back("--unshare-pid"); // Isolate PIDs
                 // Bind current dir
@@ -158,7 +160,8 @@ public:
 
                 int ret = wait4(pid, &wstatus, WNOHANG, &usage);
                 if (ret == pid) {
-                    // Process exited
+                    // Process exited — close status file before breaking
+                    status_file.close();
                     result.cpu_time_ms = usage.ru_utime.tv_sec * 1000 + usage.ru_utime.tv_usec / 1000 +
                                          usage.ru_stime.tv_sec * 1000 + usage.ru_stime.tv_usec / 1000;
                     
@@ -189,7 +192,7 @@ public:
                                 // Likely OOM or hard crash
                                 result.status = SandboxResultStatus::RuntimeError;
                                 int threshold = limits.memory_mb - (limits.memory_mb / 10);
-                                if (threshold < limits.memory_mb - 5) threshold = limits.memory_mb - 5;
+                                threshold = std::max(0, threshold - 5);
                                 if (result.memory_mb >= threshold || sig == SIGKILL) {
                                      result.status = SandboxResultStatus::MemoryLimitExceeded;
                                 }
@@ -198,7 +201,7 @@ public:
                             result.status = SandboxResultStatus::RuntimeError;
                             // Check for MLE disguised as SEGFAULT
                             int threshold = limits.memory_mb - (limits.memory_mb / 10);
-                            if (threshold < limits.memory_mb - 5) threshold = limits.memory_mb - 5;
+                            threshold = std::max(0, threshold - 5);
                             if (result.memory_mb >= threshold) {
                                 result.status = SandboxResultStatus::MemoryLimitExceeded;
                             }
@@ -212,7 +215,7 @@ public:
                     auto now = std::chrono::steady_clock::now();
                     auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time).count();
                     
-                    if (elapsed_ms > limits.cpu_time_ms + 100) { // Slight padding
+                    if (limits.cpu_time_ms > 0 && elapsed_ms > limits.cpu_time_ms + 100) { // Slight padding
                         killpg(pid, SIGKILL); // Kill entire process group
                         result.status = SandboxResultStatus::TimeLimitExceeded;
                         result.cpu_time_ms = limits.cpu_time_ms;

--- a/src/infra/database.cpp
+++ b/src/infra/database.cpp
@@ -46,15 +46,16 @@ static Problem fill_problem_from_row(SQLite::Statement& q) {
     p.title = safe_column_text(q.getColumn(3));
     p.url = safe_column_text(q.getColumn(4));
     p.content_path = safe_column_text(q.getColumn(5));
-    p.tags = safe_column_text(q.getColumn(6));
-    p.difficulty = safe_column_text(q.getColumn(7));
-    p.created_at = q.getColumn(8).getInt64();
+    p.description = safe_column_text(q.getColumn(6));
+    p.tags = safe_column_text(q.getColumn(7));
+    p.difficulty = safe_column_text(q.getColumn(8));
+    p.created_at = q.getColumn(9).getInt64();
     
     // 安全获取可能为空的列
-    p.last_verdict = safe_column_text(q.getColumn(9));
-    try { p.pass_count = q.getColumn(10).getInt(); } catch(...) { p.pass_count = 0; }
-    try { p.total_count = q.getColumn(11).getInt(); } catch(...) { p.total_count = 0; }
-    try { p.last_checked_at = q.getColumn(12).getInt64(); } catch(...) { p.last_checked_at = 0; }
+    p.last_verdict = safe_column_text(q.getColumn(10));
+    try { p.pass_count = q.getColumn(11).getInt(); } catch(...) { p.pass_count = 0; }
+    try { p.total_count = q.getColumn(12).getInt(); } catch(...) { p.total_count = 0; }
+    try { p.last_checked_at = q.getColumn(13).getInt64(); } catch(...) { p.last_checked_at = 0; }
     
     return p;
 }
@@ -87,6 +88,7 @@ void Database::init_schema() {
         "  title TEXT,"
         "  url TEXT,"
         "  content_path TEXT,"
+        "  description TEXT,"
         "  tags TEXT DEFAULT '',"
         "  difficulty TEXT DEFAULT 'medium',"
         "  created_at INTEGER,"
@@ -150,11 +152,10 @@ void Database::init_schema() {
         "CREATE TABLE IF NOT EXISTS memory_mistakes ("
         "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
         "  tags TEXT,"
-        "  pattern TEXT,"
+        "  pattern TEXT UNIQUE,"
         "  frequency INTEGER DEFAULT 1,"
         "  last_seen INTEGER,"
-        "  example_id TEXT,"
-        "  UNIQUE(tags, pattern)" 
+        "  example_id TEXT"
         ")");
 
     db_->exec(
@@ -181,6 +182,10 @@ void Database::init_schema() {
 void Database::init_indexes() {
     // 题目查询优化索引
     db_->exec("CREATE INDEX IF NOT EXISTS idx_problems_url ON problems(url)");
+    // Add UNIQUE constraint on url to prevent duplicates (ignore error if duplicates exist)
+    try {
+        db_->exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_problems_url_uniq ON problems(url)");
+    } catch (const std::exception&) {}
     db_->exec("CREATE INDEX IF NOT EXISTS idx_problems_created ON problems(created_at DESC)");
     db_->exec("CREATE INDEX IF NOT EXISTS idx_problems_difficulty ON problems(difficulty)");
     db_->exec("CREATE INDEX IF NOT EXISTS idx_problems_source ON problems(source)");
@@ -214,12 +219,13 @@ void Database::init_indexes() {
 
 void Database::add_problem(const Problem& p) {
     SQLite::Statement q(*db_,
-        "INSERT INTO problems (id,source,title,url,content_path,tags,difficulty,created_at,"
+        "INSERT INTO problems (id,source,title,url,content_path,description,tags,difficulty,created_at,"
         "last_verdict,pass_count,total_count,last_checked_at) "
-        "VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12) "
+        "VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13) "
         "ON CONFLICT(id) DO UPDATE SET "
         "source=excluded.source, title=excluded.title, url=excluded.url, "
-        "content_path=excluded.content_path, tags=excluded.tags, difficulty=excluded.difficulty, "
+        "content_path=excluded.content_path, description=excluded.description, "
+        "tags=excluded.tags, difficulty=excluded.difficulty, "
         "created_at=excluded.created_at, last_verdict=excluded.last_verdict, "
         "pass_count=excluded.pass_count, total_count=excluded.total_count, last_checked_at=excluded.last_checked_at");
     q.bind(1, ensure_utf8_lossy(p.id));
@@ -227,13 +233,14 @@ void Database::add_problem(const Problem& p) {
     q.bind(3, ensure_utf8_lossy(p.title));
     q.bind(4, ensure_utf8_lossy(p.url));
     q.bind(5, ensure_utf8_lossy(p.content_path));
-    q.bind(6, ensure_utf8_lossy(p.tags));
-    q.bind(7, ensure_utf8_lossy(p.difficulty));
-    q.bind(8, static_cast<int64_t>(p.created_at ? p.created_at : std::time(nullptr)));
-    q.bind(9, ensure_utf8_lossy(p.last_verdict));
-    q.bind(10, p.pass_count);
-    q.bind(11, p.total_count);
-    q.bind(12, static_cast<int64_t>(p.last_checked_at));
+    q.bind(6, ensure_utf8_lossy(p.description));
+    q.bind(7, ensure_utf8_lossy(p.tags));
+    q.bind(8, ensure_utf8_lossy(p.difficulty));
+    q.bind(9, static_cast<int64_t>(p.created_at ? p.created_at : std::time(nullptr)));
+    q.bind(10, ensure_utf8_lossy(p.last_verdict));
+    q.bind(11, p.pass_count);
+    q.bind(12, p.total_count);
+    q.bind(13, static_cast<int64_t>(p.last_checked_at));
     q.exec();
 }
 
@@ -248,7 +255,7 @@ std::vector<Problem> Database::get_all_problems() {
     out.reserve(100); // 预分配空间优化
     
     SQLite::Statement q(*db_, 
-        "SELECT rowid, id,source,title,url,content_path,tags,difficulty,created_at, "
+        "SELECT rowid, id,source,title,url,content_path,description,tags,difficulty,created_at, "
         "last_verdict, pass_count, total_count, last_checked_at "
         "FROM problems ORDER BY created_at DESC");
     while (q.executeStep()) {
@@ -259,7 +266,7 @@ std::vector<Problem> Database::get_all_problems() {
 
 Problem Database::get_problem(const std::string& id) {
     SQLite::Statement q(*db_, 
-        "SELECT rowid, id,source,title,url,content_path,tags,difficulty,created_at, "
+        "SELECT rowid, id,source,title,url,content_path,description,tags,difficulty,created_at, "
         "last_verdict, pass_count, total_count, last_checked_at "
         "FROM problems WHERE id=? LIMIT 1");
     q.bind(1, ensure_utf8_lossy(id));
@@ -271,7 +278,7 @@ Problem Database::get_problem(const std::string& id) {
 
 Problem Database::get_problem_by_display_id(int tid) {
     SQLite::Statement q(*db_, 
-        "SELECT rowid, id,source,title,url,content_path,tags,difficulty,created_at, "
+        "SELECT rowid, id,source,title,url,content_path,description,tags,difficulty,created_at, "
         "last_verdict, pass_count, total_count, last_checked_at "
         "FROM problems WHERE rowid=? LIMIT 1");
     q.bind(1, tid);
@@ -532,15 +539,22 @@ std::vector<Mastery> Database::get_all_mastery() {
 // ---- User Profile ----
 
 void Database::update_user_profile(int elo, const std::string& preferences) {
-    if (elo > 0) {
-        SQLite::Statement q(*db_, "UPDATE user_profile SET elo_rating=? WHERE id=1");
-        q.bind(1, elo);
-        q.exec();
-    }
-    if (!preferences.empty()) {
-        SQLite::Statement q(*db_, "UPDATE user_profile SET preferences=? WHERE id=1");
-        q.bind(1, ensure_utf8_lossy(preferences));
-        q.exec();
+    db_->exec("BEGIN");
+    try {
+        if (elo > 0) {
+            SQLite::Statement q(*db_, "UPDATE user_profile SET elo_rating=? WHERE id=1");
+            q.bind(1, elo);
+            q.exec();
+        }
+        if (!preferences.empty()) {
+            SQLite::Statement q(*db_, "UPDATE user_profile SET preferences=? WHERE id=1");
+            q.bind(1, ensure_utf8_lossy(preferences));
+            q.exec();
+        }
+        db_->exec("COMMIT");
+    } catch (...) {
+        db_->exec("ROLLBACK");
+        throw;
     }
 }
 


### PR DESCRIPTION
## Summary

Bug fixes from automated audit (sandbox + judge core + compiler doctor + AI coach + crawler):

### Sandbox fixes (`sandbox_linux.cpp`)
- **FD leak**: close `/proc/<pid>/status` fd when process exits
- **has_bwrap()**: cache result with `static bool` to avoid repeated `fork+exec`
- **MLE threshold underflow**: fix `threshold` going negative for small memory limits (`std::max(0, threshold - 5)`)
- **Time limit = 0**: add guard — processes without time limits were being killed after 100ms
- **bwrap `/dev` exposure**: use `/dev/shm` instead of full `/dev` to avoid block device nodes
- **bwrap missing `/usr/local`**: add `--ro-bind /usr/local` for non-standard `g++` paths

### Judge fix (`judge.cpp`)
- **Redundant verdict=AC overwriting WA**: removed erroneous `else { verdict=AC }` that overwrote WA from `check_output()`

### Compiler Doctor fix (`compiler_doctor.cpp`)
- **Thread race**: `rules_loaded_` was checked+set without synchronization — replaced with `std::call_once`

### AI Coach fix (`ai_coach.cpp`)
- **OOM guard**: cap SSE response buffer at 50MB

### Luogu Crawler fix (`luogu_crawler.cpp`)
- **Difficulty mapping**: case 3 (提高) and case 4 (提高+/省选-) now correctly map to `medium`

### Database schema fixes (`database.cpp`)
- **`memory_mistakes`**: change `UNIQUE(tags, pattern)` to `UNIQUE(pattern)` — fixes UPSERT `ON CONFLICT(pattern)` ambiguity causing same-pattern different-tag records to silently overwrite each other
- **Add `description` column** to `problems` table (was declared in `types.hpp` but missing from schema)
- **Add UNIQUE index on `problems(url)`** to prevent duplicate URLs
- **Wrap `update_user_profile()` in `BEGIN/COMMIT` transaction** — elo and preferences updates are now atomic

### Problem manager fixes (`problem_manager.cpp`)
- **`pull_problem`**: write file to disk ONLY after DB insert succeeds (DB is source of truth)
- **`delete_problem`**: delete from DB BEFORE deleting files (DB first, files after; rollback-safe)

### CI fix (`.github/workflows/ci.yml`)
- **Smoke test**: `status` subcommand does not exist; replaced with `list -f all` as smoke test command

---
*Audit performed by panda (edict system) on 2026-04-09*
